### PR TITLE
PTEC en string

### DIFF
--- a/core/class/teleinfo.class.php
+++ b/core/class/teleinfo.class.php
@@ -103,6 +103,7 @@ class teleinfo extends eqLogic
                 case "PPOT":
                 case "PEJP":
                 case "DEMAIN":
+                case "PTEC":
                     $cmd->setSubType('string');
                     $cmd->setDisplay('generic_type', 'GENERIC_INFO');
                     break;


### PR DESCRIPTION
La commande PTEC doit être de type string (HP/HC)