### PR TITLE
Besoin de pouvoir accéder à la liste des tty si l'on utilise des aliases

### DIFF
--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -50,6 +50,9 @@ try {
                     foreach (jeedom::getUsbMapping() as $name => $value) {
                         echo '<option value="' . $name . '">' . $name . ' (' . $value . ')</option>';
                     }
+                    foreach (ls('/dev/', 'tty*') as $value) {
+                        echo '<option value="/dev/' . $value . '">/dev/' . $value . '</option>';
+                    }
                     echo '<option value="serie">Modem Série</option>';
                     ?>
                 </select>


### PR DESCRIPTION
Pour éviter que le port USB ne bouge, utilisation de udev pour fixer le port avec le device utilisé, d'où la nécessité de donner un nom spécifique au port (qui sera un alias), par exemple /dev/ttyTeleinfo (qui pointera vers /dev/ttyUSB0 par exemple), mais avec le code actuel, pas d'affichage de ces aliases.